### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# scalafmt
+
+917e5423c9a28c7bdf902d7794bc51a6e6a3a1c4


### PR DESCRIPTION
Adds `scalafmt` commit to `.git-blame-ignore-revs`